### PR TITLE
module.exports instead of export default

### DIFF
--- a/lib/page.vue
+++ b/lib/page.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script>
-module.exports = {
+export default {
   computed: {
     pageClass () {
       const transitionClass = this.$store.getters["router/transitionForPage"](this.name)


### PR DESCRIPTION
To resolve https://github.com/geekytime/vuex-router/issues/9 raised by @faisalarbain.